### PR TITLE
feat: adjust eraser pressure for UX

### DIFF
--- a/src/utils/Geometry.cpp
+++ b/src/utils/Geometry.cpp
@@ -40,7 +40,7 @@ void DrawingWidget::drawLineToFunc(qint64 id, qreal pressure) {
             break;
         case ERASER:
             painter.setCompositionMode(QPainter::CompositionMode_Clear);
-            pressure = 1.0;
+            pressure = normalizePressure(pressure);
             break;
         case MARKER:
             penColor.setAlpha(127);

--- a/src/widgets/DrawingWidget.cpp
+++ b/src/widgets/DrawingWidget.cpp
@@ -49,6 +49,8 @@ penType:
 #define HISTORY 15
 #endif
 
+#define MIN(x, y) (((x) < (y)) ? (x) : (y))
+
 class CursorStorage {
 public:
     void init(qint64 id){
@@ -486,7 +488,7 @@ void DrawingWidget::eventHandler(int source, int type, int id, QPointF pos, floa
                 break;
             }
             if(penType == ERASER) {
-                curs.setCursor(id, penSize[penType]);
+                curs.setCursor(id, penSize[penType] * normalizePressure(pressure));
                 curs.setPosition(id, pos);
             } else {
                 curs.hide(id);
@@ -499,6 +501,7 @@ void DrawingWidget::eventHandler(int source, int type, int id, QPointF pos, floa
                     case DRAW:
                         if(penType == ERASER) {
                             curs.setPosition(id, pos);
+                            curs.setCursor(id, penSize[penType] * normalizePressure(pressure));
                         }
                         addPoint(id, pos);
                         drawLineToFunc(id, pressure);
@@ -668,3 +671,18 @@ void qImageToFile(const QImage& image, const QString& filename) {
         }
 }
 
+
+// Process and normalize raw pressure input to improve user experience
+// returns float value between `1.0` and `base` (0.1)
+float DrawingWidget::normalizePressure(float pressure) {
+    float base = 0.1;
+    float multiplier = 1.5;
+    switch(penType){
+        case ERASER:
+            return MIN(1.0 , pressure * multiplier + base);
+            break;
+        default:
+            return pressure;
+            break;
+    }
+}

--- a/src/widgets/DrawingWidget.h
+++ b/src/widgets/DrawingWidget.h
@@ -160,6 +160,7 @@ protected:
     void selectionDraw(QPointF startPoint, QPointF endPoint);
     void addPoint(int id, QPointF data);
     bool event(QEvent * ev) override;
+    float normalizePressure(float pressure);
     GeometryStorage geo;
     QPainter painter;
 };


### PR DESCRIPTION
- change cursor size
- normalize pressure (with a multiplier)

Tested some multiplier values with my graphic tablet and decided to use 1.5x as default. Wrote a function to easily change this value if needed

I'm not good at OOP, code corrections are welcome