### PR TITLE
fix: unset QT_STYLE_OVERRIDE on startup

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,8 @@ int main(int argc, char *argv[]) {
     setenv("QT_AUTO_SCREEN_SCALE_FACTOR", "0", 1);
     setenv("QT_QT_ENABLE_HIGHDPI_SCALING", "0", 1);
     setenv("QT_SCALE_FACTOR", "1", 1);
+    //unset qt style override, there's a bug with input when using qt6 build and kvantum
+    setenv("QT_STYLE_OVERRIDE", "", 1);
 
     // history size
     history = get_int("history");


### PR DESCRIPTION
when building with qt6 and using a kvantum style for some reason the window will detect an input at coordinate (0,0) in the upper left corner and won't let the user paint. Unsetting the env variable fixes it