### PR TITLE
Enhance screenshot dialogs

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-22 11:19+0000\n"
+"POT-Creation-Date: 2025-05-30 20:16+0300\n"
 "PO-Revision-Date: 2024-10-26 15:14-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,79 +17,93 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: src/tools/pen.cpp:165
-msgid "Select Color"
-msgstr "Seleccione el color"
+#: src/tools/background.cpp:60
+msgid "Images"
+msgstr ""
 
-#: src/tools/mainWindow.cpp:271 src/main.cpp:73
-msgid "Pardus Pen"
-msgstr "Lápiz Pardus"
-
-#: src/tools/save-load.cpp:44 src/tools/save-load.cpp:73
-#, fuzzy
-msgid "Pen Files (*.pen);;"
-msgstr "Archivos de lápiz (*.pen);;Todos los archivos (*.*)"
-
-#: src/tools/save-load.cpp:46 src/tools/save-load.cpp:75
-#, fuzzy
-msgid "PDF Files (*.pdf);;"
-msgstr "Archivos de lápiz (*.pen);;Todos los archivos (*.*)"
-
-#: src/tools/save-load.cpp:48 src/tools/save-load.cpp:77
-#: src/tools/background.cpp:71
+#: src/tools/background.cpp:61 src/tools/save-load.cpp:50
+#: src/tools/save-load.cpp:79
 #, fuzzy
 msgid "All Files (*.*)"
 msgstr "Archivos de lápiz (*.pen);;Todos los archivos (*.*)"
 
-#: src/tools/save-load.cpp:53
-msgid "Save File"
-msgstr "Guardar archivo"
-
-#: src/tools/save-load.cpp:81
-msgid "Open File"
-msgstr "Abrir archivo"
-
-#: src/tools/background.cpp:70
-msgid "Images"
-msgstr ""
-
-#: src/tools/background.cpp:75
+#: src/tools/background.cpp:65
 #, fuzzy
 msgid "Open Image File"
 msgstr "Abrir archivo"
 
-#: src/tools/background.cpp:94
+#: src/tools/background.cpp:85
 msgid "Go page"
 msgstr ""
 
-#: src/tools/background.cpp:95 src/SetupWidgets.cpp:237
+#: src/tools/background.cpp:86 src/SetupWidgets.cpp:313
 msgid "Page:"
 msgstr ""
 
-#: src/tools/update.cpp:32
+#: src/tools/mainWindow.cpp:268 src/main.cpp:73
+msgid "Pardus Pen"
+msgstr "Lápiz Pardus"
+
+#: src/tools/pen.cpp:139 src/tools/update.cpp:42
 msgid "Size:"
 msgstr "Tamaño:"
 
-#: src/utils/ScreenShot.cpp:58
-msgid "Info"
-msgstr "Información"
+#: src/tools/pen.cpp:162
+msgid "Select Color"
+msgstr "Seleccione el color"
 
-#: src/utils/ScreenShot.cpp:61
-msgid "Screenshot saved:"
+#: src/tools/save-load.cpp:46 src/tools/save-load.cpp:75
+#, fuzzy
+msgid "Pen Files (*.pen);;"
+msgstr "Archivos de lápiz (*.pen);;Todos los archivos (*.*)"
+
+#: src/tools/save-load.cpp:48 src/tools/save-load.cpp:77
+#, fuzzy
+msgid "PDF Files (*.pdf);;"
+msgstr "Archivos de lápiz (*.pen);;Todos los archivos (*.*)"
+
+#: src/tools/save-load.cpp:55
+msgid "Save File"
+msgstr "Guardar archivo"
+
+#: src/tools/save-load.cpp:83 src/utils/ScreenShot.cpp:68
+msgid "Open File"
+msgstr "Abrir archivo"
+
+#: src/utils/ScreenShot.cpp:65
+#, fuzzy
+msgid "Screenshot Saved"
 msgstr "Captura de pantalla guardada:"
 
-#: src/utils/ScreenShot.cpp:63
-msgid "Failed To save:"
+#: src/utils/ScreenShot.cpp:66
+#, fuzzy
+msgid "Screenshot saved to:"
+msgstr "Captura de pantalla guardada:"
+
+#: src/utils/ScreenShot.cpp:69
+msgid "Open Containing Folder"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:84
+msgid "Error Saving Screenshot"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:85
+#, fuzzy
+msgid "Failed to save screenshot to:"
 msgstr "Error al guardar:"
 
-#: src/SetupWidgets.cpp:114
+#: src/SetupWidgets.cpp:158
 #, fuzzy
 msgid "Size: 10"
 msgstr "Tamaño:"
 
-#: src/SetupWidgets.cpp:258
+#: src/SetupWidgets.cpp:356
 msgid "Background:"
 msgstr ""
+
+#~ msgid "Info"
+#~ msgstr "Información"
 
 #~ msgid "Pen"
 #~ msgstr "Lápiz"

--- a/po/pardus-pen.pot
+++ b/po/pardus-pen.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-22 11:19+0000\n"
+"POT-Creation-Date: 2025-05-30 20:16+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,71 +17,79 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/tools/pen.cpp:165
-msgid "Select Color"
-msgstr ""
-
-#: src/tools/mainWindow.cpp:271 src/main.cpp:73
-msgid "Pardus Pen"
-msgstr ""
-
-#: src/tools/save-load.cpp:44 src/tools/save-load.cpp:73
-msgid "Pen Files (*.pen);;"
-msgstr ""
-
-#: src/tools/save-load.cpp:46 src/tools/save-load.cpp:75
-msgid "PDF Files (*.pdf);;"
-msgstr ""
-
-#: src/tools/save-load.cpp:48 src/tools/save-load.cpp:77
-#: src/tools/background.cpp:71
-msgid "All Files (*.*)"
-msgstr ""
-
-#: src/tools/save-load.cpp:53
-msgid "Save File"
-msgstr ""
-
-#: src/tools/save-load.cpp:81
-msgid "Open File"
-msgstr ""
-
-#: src/tools/background.cpp:70
+#: src/tools/background.cpp:60
 msgid "Images"
 msgstr ""
 
-#: src/tools/background.cpp:75
+#: src/tools/background.cpp:61 src/tools/save-load.cpp:50
+#: src/tools/save-load.cpp:79
+msgid "All Files (*.*)"
+msgstr ""
+
+#: src/tools/background.cpp:65
 msgid "Open Image File"
 msgstr ""
 
-#: src/tools/background.cpp:94
+#: src/tools/background.cpp:85
 msgid "Go page"
 msgstr ""
 
-#: src/tools/background.cpp:95 src/SetupWidgets.cpp:237
+#: src/tools/background.cpp:86 src/SetupWidgets.cpp:313
 msgid "Page:"
 msgstr ""
 
-#: src/tools/update.cpp:32
+#: src/tools/mainWindow.cpp:268 src/main.cpp:73
+msgid "Pardus Pen"
+msgstr ""
+
+#: src/tools/pen.cpp:139 src/tools/update.cpp:42
 msgid "Size:"
 msgstr ""
 
-#: src/utils/ScreenShot.cpp:58
-msgid "Info"
+#: src/tools/pen.cpp:162
+msgid "Select Color"
 msgstr ""
 
-#: src/utils/ScreenShot.cpp:61
-msgid "Screenshot saved:"
+#: src/tools/save-load.cpp:46 src/tools/save-load.cpp:75
+msgid "Pen Files (*.pen);;"
 msgstr ""
 
-#: src/utils/ScreenShot.cpp:63
-msgid "Failed To save:"
+#: src/tools/save-load.cpp:48 src/tools/save-load.cpp:77
+msgid "PDF Files (*.pdf);;"
 msgstr ""
 
-#: src/SetupWidgets.cpp:114
+#: src/tools/save-load.cpp:55
+msgid "Save File"
+msgstr ""
+
+#: src/tools/save-load.cpp:83 src/utils/ScreenShot.cpp:68
+msgid "Open File"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:65
+msgid "Screenshot Saved"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:66
+msgid "Screenshot saved to:"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:69
+msgid "Open Containing Folder"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:84
+msgid "Error Saving Screenshot"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:85
+msgid "Failed to save screenshot to:"
+msgstr ""
+
+#: src/SetupWidgets.cpp:158
 msgid "Size: 10"
 msgstr ""
 
-#: src/SetupWidgets.cpp:258
+#: src/SetupWidgets.cpp:356
 msgid "Background:"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tr.org.pardus.pen master\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-22 11:19+0000\n"
+"POT-Creation-Date: 2025-05-30 20:16+0300\n"
 "PO-Revision-Date: 2025-01-03 20:23+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <hugokarvalho@hotmail.com>\n"
@@ -19,74 +19,88 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.5\n"
 
-#: src/tools/pen.cpp:165
-msgid "Select Color"
-msgstr "Selecionar cor"
-
-#: src/tools/mainWindow.cpp:271 src/main.cpp:73
-msgid "Pardus Pen"
-msgstr "Caneta Pardus"
-
-#: src/tools/save-load.cpp:44 src/tools/save-load.cpp:73
-msgid "Pen Files (*.pen);;"
-msgstr "Ficheiros de caneta (*.pen);;"
-
-#: src/tools/save-load.cpp:46 src/tools/save-load.cpp:75
-msgid "PDF Files (*.pdf);;"
-msgstr "Ficheiros PDF (*.pdf);;"
-
-#: src/tools/save-load.cpp:48 src/tools/save-load.cpp:77
-#: src/tools/background.cpp:71
-msgid "All Files (*.*)"
-msgstr "Todos os ficheiros (*.*)"
-
-#: src/tools/save-load.cpp:53
-msgid "Save File"
-msgstr "Guardar ficheiro"
-
-#: src/tools/save-load.cpp:81
-msgid "Open File"
-msgstr "Abrir ficheiro"
-
-#: src/tools/background.cpp:70
+#: src/tools/background.cpp:60
 msgid "Images"
 msgstr "Imagens"
 
-#: src/tools/background.cpp:75
+#: src/tools/background.cpp:61 src/tools/save-load.cpp:50
+#: src/tools/save-load.cpp:79
+msgid "All Files (*.*)"
+msgstr "Todos os ficheiros (*.*)"
+
+#: src/tools/background.cpp:65
 msgid "Open Image File"
 msgstr "Abrir imagem"
 
-#: src/tools/background.cpp:94
+#: src/tools/background.cpp:85
 msgid "Go page"
 msgstr ""
 
-#: src/tools/background.cpp:95 src/SetupWidgets.cpp:237
+#: src/tools/background.cpp:86 src/SetupWidgets.cpp:313
 msgid "Page:"
 msgstr "Página:"
 
-#: src/tools/update.cpp:32
+#: src/tools/mainWindow.cpp:268 src/main.cpp:73
+msgid "Pardus Pen"
+msgstr "Caneta Pardus"
+
+#: src/tools/pen.cpp:139 src/tools/update.cpp:42
 msgid "Size:"
 msgstr "Tamanho:"
 
-#: src/utils/ScreenShot.cpp:58
-msgid "Info"
-msgstr "Informação"
+#: src/tools/pen.cpp:162
+msgid "Select Color"
+msgstr "Selecionar cor"
 
-#: src/utils/ScreenShot.cpp:61
-msgid "Screenshot saved:"
+#: src/tools/save-load.cpp:46 src/tools/save-load.cpp:75
+msgid "Pen Files (*.pen);;"
+msgstr "Ficheiros de caneta (*.pen);;"
+
+#: src/tools/save-load.cpp:48 src/tools/save-load.cpp:77
+msgid "PDF Files (*.pdf);;"
+msgstr "Ficheiros PDF (*.pdf);;"
+
+#: src/tools/save-load.cpp:55
+msgid "Save File"
+msgstr "Guardar ficheiro"
+
+#: src/tools/save-load.cpp:83 src/utils/ScreenShot.cpp:68
+msgid "Open File"
+msgstr "Abrir ficheiro"
+
+#: src/utils/ScreenShot.cpp:65
+#, fuzzy
+msgid "Screenshot Saved"
 msgstr "Captura de ecrã guardada:"
 
-#: src/utils/ScreenShot.cpp:63
-msgid "Failed To save:"
+#: src/utils/ScreenShot.cpp:66
+#, fuzzy
+msgid "Screenshot saved to:"
+msgstr "Captura de ecrã guardada:"
+
+#: src/utils/ScreenShot.cpp:69
+msgid "Open Containing Folder"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:84
+msgid "Error Saving Screenshot"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:85
+#, fuzzy
+msgid "Failed to save screenshot to:"
 msgstr "Erro ao guardar:"
 
-#: src/SetupWidgets.cpp:114
+#: src/SetupWidgets.cpp:158
 msgid "Size: 10"
 msgstr "Tamanho: 10"
 
-#: src/SetupWidgets.cpp:258
+#: src/SetupWidgets.cpp:356
 msgid "Background:"
 msgstr "Fundo:"
+
+#~ msgid "Info"
+#~ msgstr "Informação"
 
 #~ msgid "Pen"
 #~ msgstr "Caneta"

--- a/po/tr.po
+++ b/po/tr.po
@@ -9,15 +9,15 @@ msgstr ""
 "Project-Id-Version: tr.org.pardus.pen master\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-05-30 20:16+0300\n"
-"PO-Revision-Date: 2024-08-07 00:19+0300\n"
-"Last-Translator: Sabri Ünal <yakushabb@gmail.com>\n"
+"PO-Revision-Date: 2025-05-30 20:21+0300\n"
+"Last-Translator: Edip Hazuri <edip@medip.dev>\n"
 "Language-Team: Turkish <kde-l10n-tr@kde.org>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Generator: Poedit 3.4.3\n"
+"X-Generator: Poedit 3.6\n"
 
 #: src/tools/background.cpp:60
 msgid "Images"
@@ -69,14 +69,12 @@ msgid "Open File"
 msgstr "Dosya Aç"
 
 #: src/utils/ScreenShot.cpp:65
-#, fuzzy
 msgid "Screenshot Saved"
-msgstr "Ekran görüntüsü kaydedildi:"
+msgstr "Ekran görüntüsü kaydedildi"
 
 #: src/utils/ScreenShot.cpp:66
-#, fuzzy
 msgid "Screenshot saved to:"
-msgstr "Ekran görüntüsü kaydedildi:"
+msgstr "Ekran görüntüsü şuraya kaydedildi:"
 
 #: src/utils/ScreenShot.cpp:69
 msgid "Open Containing Folder"
@@ -84,12 +82,11 @@ msgstr ""
 
 #: src/utils/ScreenShot.cpp:84
 msgid "Error Saving Screenshot"
-msgstr ""
+msgstr "Ekran görüntüsü kaydedilemedi"
 
 #: src/utils/ScreenShot.cpp:85
-#, fuzzy
 msgid "Failed to save screenshot to:"
-msgstr "Kaydedilemedi:"
+msgstr "Ekran görüntüsü şuraya kaydedilemedi:"
 
 #: src/SetupWidgets.cpp:158
 msgid "Size: 10"
@@ -97,7 +94,7 @@ msgstr "Boyut: 10"
 
 #: src/SetupWidgets.cpp:356
 msgid "Background:"
-msgstr "Arka Plan"
+msgstr "Arka Plan:"
 
 #~ msgid "Info"
 #~ msgstr "Bilgi"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tr.org.pardus.pen master\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-22 11:19+0000\n"
+"POT-Creation-Date: 2025-05-30 20:16+0300\n"
 "PO-Revision-Date: 2024-08-07 00:19+0300\n"
 "Last-Translator: Sabri Ünal <yakushabb@gmail.com>\n"
 "Language-Team: Turkish <kde-l10n-tr@kde.org>\n"
@@ -19,71 +19,85 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Generator: Poedit 3.4.3\n"
 
-#: src/tools/pen.cpp:165
-msgid "Select Color"
-msgstr "Renk Seçin"
-
-#: src/tools/mainWindow.cpp:271 src/main.cpp:73
-msgid "Pardus Pen"
-msgstr "Pardus Kalem"
-
-#: src/tools/save-load.cpp:44 src/tools/save-load.cpp:73
-msgid "Pen Files (*.pen);;"
-msgstr "Kalem Dosyaları (*.pen);;"
-
-#: src/tools/save-load.cpp:46 src/tools/save-load.cpp:75
-msgid "PDF Files (*.pdf);;"
-msgstr "PDF  Dosyaları (*.pdf);;"
-
-#: src/tools/save-load.cpp:48 src/tools/save-load.cpp:77
-#: src/tools/background.cpp:71
-msgid "All Files (*.*)"
-msgstr "Tüm Dosyalar (*.*)"
-
-#: src/tools/save-load.cpp:53
-msgid "Save File"
-msgstr "Dosya Kaydet"
-
-#: src/tools/save-load.cpp:81
-msgid "Open File"
-msgstr "Dosya Aç"
-
-#: src/tools/background.cpp:70
+#: src/tools/background.cpp:60
 msgid "Images"
 msgstr "Resimler"
 
-#: src/tools/background.cpp:75
+#: src/tools/background.cpp:61 src/tools/save-load.cpp:50
+#: src/tools/save-load.cpp:79
+msgid "All Files (*.*)"
+msgstr "Tüm Dosyalar (*.*)"
+
+#: src/tools/background.cpp:65
 msgid "Open Image File"
 msgstr "Resim Aç"
 
-#: src/tools/background.cpp:94
+#: src/tools/background.cpp:85
 msgid "Go page"
 msgstr "Sayfaya git"
 
-#: src/tools/background.cpp:95 src/SetupWidgets.cpp:237
+#: src/tools/background.cpp:86 src/SetupWidgets.cpp:313
 msgid "Page:"
 msgstr "Sayfa:"
 
-#: src/tools/update.cpp:32
+#: src/tools/mainWindow.cpp:268 src/main.cpp:73
+msgid "Pardus Pen"
+msgstr "Pardus Kalem"
+
+#: src/tools/pen.cpp:139 src/tools/update.cpp:42
 msgid "Size:"
 msgstr "Boyutu:"
 
-#: src/utils/ScreenShot.cpp:58
-msgid "Info"
-msgstr "Bilgi"
+#: src/tools/pen.cpp:162
+msgid "Select Color"
+msgstr "Renk Seçin"
 
-#: src/utils/ScreenShot.cpp:61
-msgid "Screenshot saved:"
+#: src/tools/save-load.cpp:46 src/tools/save-load.cpp:75
+msgid "Pen Files (*.pen);;"
+msgstr "Kalem Dosyaları (*.pen);;"
+
+#: src/tools/save-load.cpp:48 src/tools/save-load.cpp:77
+msgid "PDF Files (*.pdf);;"
+msgstr "PDF  Dosyaları (*.pdf);;"
+
+#: src/tools/save-load.cpp:55
+msgid "Save File"
+msgstr "Dosya Kaydet"
+
+#: src/tools/save-load.cpp:83 src/utils/ScreenShot.cpp:68
+msgid "Open File"
+msgstr "Dosya Aç"
+
+#: src/utils/ScreenShot.cpp:65
+#, fuzzy
+msgid "Screenshot Saved"
 msgstr "Ekran görüntüsü kaydedildi:"
 
-#: src/utils/ScreenShot.cpp:63
-msgid "Failed To save:"
+#: src/utils/ScreenShot.cpp:66
+#, fuzzy
+msgid "Screenshot saved to:"
+msgstr "Ekran görüntüsü kaydedildi:"
+
+#: src/utils/ScreenShot.cpp:69
+msgid "Open Containing Folder"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:84
+msgid "Error Saving Screenshot"
+msgstr ""
+
+#: src/utils/ScreenShot.cpp:85
+#, fuzzy
+msgid "Failed to save screenshot to:"
 msgstr "Kaydedilemedi:"
 
-#: src/SetupWidgets.cpp:114
+#: src/SetupWidgets.cpp:158
 msgid "Size: 10"
 msgstr "Boyut: 10"
 
-#: src/SetupWidgets.cpp:258
+#: src/SetupWidgets.cpp:356
 msgid "Background:"
 msgstr "Arka Plan"
+
+#~ msgid "Info"
+#~ msgstr "Bilgi"

--- a/src/utils/ScreenShot.cpp
+++ b/src/utils/ScreenShot.cpp
@@ -5,6 +5,10 @@
 
 #include <iostream>
 
+#include <QDesktopServices>
+#include <QUrl>
+#include <QFileInfo>
+
 #include "../utils/ScreenShot.h"
 #include "../widgets/DrawingWidget.h"
 
@@ -55,16 +59,34 @@ void takeScreenshot(){
     QMessageBox messageBox;
     Qt::WindowFlags flags =  Qt::Dialog | Qt::X11BypassWindowManagerHint;
     messageBox.setWindowFlags(flags);
-    messageBox.setText(_("Info"));
-    std::string msg;
+    
     if (status == 0){
-        msg = _("Screenshot saved:") + imgname.toStdString() + "\n";
+        messageBox.setIcon(QMessageBox::Information);
+        messageBox.setText(_("Screenshot Saved"));
+        messageBox.setInformativeText(_("Screenshot saved to:") + imgname);
+
+        QPushButton *openFileButton = messageBox.addButton(_("Open File"), QMessageBox::ActionRole);
+        QPushButton *openFolderButton = messageBox.addButton(_("Open Containing Folder"), QMessageBox::ActionRole);
+        messageBox.addButton(QMessageBox::Ok);
+
+        messageBox.exec();
+
+        if (messageBox.clickedButton() == openFileButton) {
+            QDesktopServices::openUrl(QUrl::fromLocalFile(imgname));
+        } else if (messageBox.clickedButton() == openFolderButton) {
+            QFileInfo fileInfo(imgname);
+            QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.absolutePath()));
+        }
+        delete openFileButton;
+        delete openFolderButton;
     } else {
-        msg = _("Failed To save:") + imgname.toStdString() + "\n";
+        messageBox.setIcon(QMessageBox::Warning);
+        messageBox.setText(_("Error Saving Screenshot"));
+        std::string fail_msg_str = _("Failed to save screenshot to:") + imgname.toStdString();
+        messageBox.setInformativeText(QString::fromStdString(fail_msg_str));
+        messageBox.addButton(QMessageBox::Ok);
+        messageBox.exec();
     }
-    messageBox.setInformativeText(msg.c_str());
-    messageBox.setIcon(QMessageBox::Information);
-    messageBox.exec();
 }
 
 #endif


### PR DESCRIPTION
- Adds "Open File" and "Open Containing Folder" buttons to the
  success dialog, allowing users to quickly access the screenshot.
- Changes the failure dialog to use a warning icon for better
  visual feedback.

before:
![Screenshot_20250530_185851](https://github.com/user-attachments/assets/3713f781-fc0c-4cd4-8346-66e0325e07d5)
![image](https://github.com/user-attachments/assets/d158db4f-584d-489c-b71a-ba73b5ea51c8)
after:
![image](https://github.com/user-attachments/assets/b029b655-e4ad-4d0e-8613-188e47c96784)
![image](https://github.com/user-attachments/assets/d324ab2e-5544-4c34-80a7-0f7df0d68fd2)
