### PR TITLE
Updated debian dependencies

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Simple qt based pen application
 ### Installing Dependencies
 For debian:
 
-`apt install meson ninja-build qtbase5-dev qtchooser libglib2.0-dev`
+`apt install meson ninja-build qtbase5-dev qtchooser libglib2.0-dev libarchive-dev qt6-svg-dev libpoppler-qt6-dev`
 
 For archlinux:
 


### PR DESCRIPTION
I needed to install more packages than was listed (Linux Mint 22.3)

There are likely more packages that need to be added for other systems as well but I cannot test for those.

Debian bağımlılıkları güncellendi - Kendi sistemimde belirtilen paketler dışında daha fazla paket indirmek zorunda kaldım (Linux Mint 22.3)

Muhtemelen diğer sistemler için de daha fazla paket lazım ama onları test edemem