### PR TITLE
Fix compilation on 32-bit x86 GNU/Linux by using correct format specifiers for 32-bit data type sizes conditionally with preprocessor conditions

### DIFF
--- a/include/widgets/DrawingWidget.h
+++ b/include/widgets/DrawingWidget.h
@@ -22,7 +22,11 @@
 #else
 #include <cstdio>
 #include "../utils/misc.h"
+#ifdef __LP64__
 #define debug printf("[%s:%ld]:", __func__, get_epoch() - _cur_time); _cur_time = get_epoch(); printf
+#else
+#define debug printf("[%s:%d]:", __func__, get_epoch() - _cur_time); _cur_time = get_epoch(); printf
+#endif
 #endif
 
 #define PADDING 8*scale

--- a/src/utils/Archive.cpp
+++ b/src/utils/Archive.cpp
@@ -135,7 +135,11 @@ public:
                 while (1) {
                     char buf[4096];
                     long int r = archive_read_data(ar, buf, sizeof(buf));
+#ifdef __LP64__
                     debug("%ld %ld %s\n", r, size, entryName);
+#else
+                    debug("%ld %lld %s\n", r, size, entryName);
+#endif
                     if (r > 0){ // continue read
                         input.append(buf, r);
                     } else if (r == 0) { // done


### PR DESCRIPTION
- Fixes https://github.com/pardus/pardus-pen/issues/49