### PR TITLE
made the pen size selection background more opaque

### DIFF
--- a/src/widgets/OverView.cpp
+++ b/src/widgets/OverView.cpp
@@ -17,7 +17,7 @@
 
 OverView::OverView(QWidget *parent) : QWidget(parent) {
     setStyleSheet(
-    "background: none;");
+    "background-color: #99232323; border-radius: 16px;");
 }
 
 void OverView::updateImage(){


### PR DESCRIPTION
In the pen settings menu, especially the menu to choose the pen's thickness, the background is completely transparent, which makes it hard to tell the size of the pen in certain colors with certain background, so I made the background slightly more opaque to be easier to tell.
<img width="603" height="643" alt="image" src="https://github.com/user-attachments/assets/e25ce09f-0f58-47e1-b3a5-d30dd7b3ee57" />
As you can see in the picture, the pen thickness menu is slightly more opaque, but the background can still be seen.