### PR TITLE
Preserve selected pen when switching tools

### DIFF
--- a/include/widgets/DrawingWidget.h
+++ b/include/widgets/DrawingWidget.h
@@ -60,6 +60,7 @@ extern float scale;
 void updateGui();
 void setPen(int type);
 int getPen();
+int getLastPen();
 void setPenStyle(int style);
 void setLineStyle(int style);
 void openFile(QString filename);
@@ -69,6 +70,7 @@ void removeDirectory(const QString &path);
 void setupWidgets();
 void setupPenType();
 void setupSaveLoad();
+bool isPenType();
 
 #ifdef QPRINTER
 extern bool PDFMODE;
@@ -106,12 +108,14 @@ public:
     int getPageNum();
     bool isBackAvailable();
     bool isNextAvailable();
+    bool isPenType();
     void loadImage(int num);
     void mergeSelection();
     void clearSelection();
     void addImage(QImage img);
     void setPen(int type);
     int getPen();
+    int getLastPen();
     void setPenStyle(int type);
     int getPenStyle();
     void setLineStyle(int type);
@@ -142,6 +146,7 @@ protected:
     int penType;
     int penStyle;
     int lineStyle;
+    int lastPenType;
     GeometryStorage geo;
     StrokeVariables recognitionVariables;
     StrokeResult recognitionResult;

--- a/src/SetupWidgets.cpp
+++ b/src/SetupWidgets.cpp
@@ -44,8 +44,8 @@ void setupWidgets(){
             floatingSettings->setHide();
             return;
         }
-        if(drawing->getPen() != PEN || drawing->getPenStyle() != SPLINE){
-            setPen(PEN);
+        if(!drawing->isPenType() || drawing->getPenStyle() != SPLINE){
+            setPen(drawing->getLastPen());
             setPenStyle(SPLINE);
             floatingSettings->setHide();
             return;

--- a/src/tools/update.cpp
+++ b/src/tools/update.cpp
@@ -32,7 +32,7 @@ void updateGui(){
     } else if (pen == ERASER){
         toolButtons[ERASERMENU]->setStyleSheet("background-color:"+drawing->pen.color().name()+";");
     } else {
-        set_icon(get_icon_by_id(PEN), toolButtons[PENMENU]);
+        set_icon(get_icon_by_id(drawing->getLastPen()), toolButtons[PENMENU]);
     }
 
     // clear only previously-active buttons instead of all penButtons

--- a/src/widgets/DrawingWidget.cpp
+++ b/src/widgets/DrawingWidget.cpp
@@ -44,6 +44,7 @@ DrawingWidget::DrawingWidget(QWidget *parent): QWidget(parent) {
     penType=PEN;
     penStyle=SPLINE;
     lineStyle=NORMAL;
+    lastPenType = penType;
     setMouseTracking(true);
     setAttribute(Qt::WA_AcceptTouchEvents);
     num_of_press = 0;
@@ -243,6 +244,9 @@ void DrawingWidget::setPen(int type){
         if(penType == PENTEXT && textActive){
             commitText();
         }
+        if(type != ERASER && type != SELECTION){
+            lastPenType = type;
+        }
         penType = type;
         QColor penColor = pen.color();
         penColor.setAlpha(255);
@@ -258,6 +262,9 @@ void DrawingWidget::setPen(int type){
 
 int DrawingWidget::getPen(){
     return penType;
+}
+int DrawingWidget::getLastPen(){
+    return lastPenType;
 }
 void DrawingWidget::setPenStyle(int type){
     penStyle = type;
@@ -573,6 +580,12 @@ bool DrawingWidget::isNextAvailable(){
     return images.last_image_num < images.image_count;
 }
 
+bool DrawingWidget::isPenType() {
+    return penType == PEN ||
+           penType == MARKER ||
+           penType == PENTEXT ||
+           penType == SMART_PEN;
+}
 
 QColor convertColor(const QColor& color) {
     int tot =  color.red() + color.blue() + color.green();


### PR DESCRIPTION
This PR fixes the pen selection behavior when switching between different tools. The last selected pen type is now preserved when using tools such as Eraser or Selection, allowing the PEN button to restore the previously selected pen instead of always falling back to the default PEN. The PEN menu icon is also updated to reflect the last selected pen type.